### PR TITLE
Fix previous slide function

### DIFF
--- a/minimal-carousel.js
+++ b/minimal-carousel.js
@@ -35,7 +35,7 @@ Carousel.prototype.prev = function () {
   for (var s = 0; s < this.slides.length; s += 1) {
     this.slides[s].style.display = 'none';
   }
-  this.current_slide = Math.abs(this.current_slide - 1) % this.slides.length;
+  this.current_slide = Math.abs(this.current_slide - 1 + this.slides.length) % this.slides.length;
   this.slides[this.current_slide].style.display = 'block';
   if (this.autoplay && this.interval) {
     var that = this;


### PR DESCRIPTION
Currently if you click on "prev()" button you just get the 1st and 2nd slide. This is due to a bug in the math function to calculate the previous slide index.
